### PR TITLE
Update homepage links

### DIFF
--- a/mupen64plus/MAKEFILE.MAK
+++ b/mupen64plus/MAKEFILE.MAK
@@ -1,6 +1,6 @@
 #/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 # *   Mupen64plus - MAKEFILE.MAK                                            *
-# *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
+# *   Mupen64Plus homepage: https://mupen64plus.org/                        *
 # *   Copyright (C) 2008 Marshallh                                          *
 # *                                                                         *
 # *   This program is free software; you can redistribute it and/or modify  *

--- a/mupen64plus/assets/LOGO_ENV.H
+++ b/mupen64plus/assets/LOGO_ENV.H
@@ -1,6 +1,6 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  *   Mupen64plus - LOGO_ENV.H                                              *
- *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
+ *   Mupen64Plus homepage: https://mupen64plus.org/                        *
  *   Copyright (C) 2008 Marshallh                                          *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *

--- a/mupen64plus/assets/box_n.h
+++ b/mupen64plus/assets/box_n.h
@@ -1,6 +1,6 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  *   Mupen64plus - box_n.h                                                 *
- *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
+ *   Mupen64Plus homepage: https://mupen64plus.org/                        *
  *   Copyright (C) 2008 Marshallh                                          *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *

--- a/mupen64plus/assets/logo.an8
+++ b/mupen64plus/assets/logo.an8
@@ -1,6 +1,6 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  *   Mupen64plus - logo.an8                                                *
- *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
+ *   Mupen64Plus homepage: https://mupen64plus.org/                        *
  *   Copyright (C) 2008 Marshallh                                          *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *

--- a/mupen64plus/assets/logo_env.an8
+++ b/mupen64plus/assets/logo_env.an8
@@ -1,6 +1,6 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  *   Mupen64plus - logo_env.an8                                            *
- *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
+ *   Mupen64Plus homepage: https://mupen64plus.org/                        *
  *   Copyright (C) 2008 Marshallh                                          *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *

--- a/mupen64plus/assets/logo_env_n.h
+++ b/mupen64plus/assets/logo_env_n.h
@@ -1,6 +1,6 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  *   Mupen64plus - logo_even_n.h                                           *
- *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
+ *   Mupen64Plus homepage: https://mupen64plus.org/                        *
  *   Copyright (C) 2008 Marshallh                                          *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *

--- a/mupen64plus/assets/logo_n.h
+++ b/mupen64plus/assets/logo_n.h
@@ -1,6 +1,6 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  *   Mupen64plus - logo_n.h                                                *
- *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
+ *   Mupen64Plus homepage: https://mupen64plus.org/                        *
  *   Copyright (C) 2008 Marshallh                                          *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *

--- a/mupen64plus/cfb.c
+++ b/mupen64plus/cfb.c
@@ -1,6 +1,6 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  *   Mupen64plus - cfb.c                                                   *
- *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
+ *   Mupen64Plus homepage: https://mupen64plus.org/                        *
  *   Copyright (C) 2008 Marshallh                                          *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *

--- a/mupen64plus/control.h
+++ b/mupen64plus/control.h
@@ -1,6 +1,6 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  *   Mupen64plus - control.h                                               *
- *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
+ *   Mupen64Plus homepage: https://mupen64plus.org/                        *
  *   Copyright (C) 2008 Marshallh                                          *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *

--- a/mupen64plus/demo.c
+++ b/mupen64plus/demo.c
@@ -1,6 +1,6 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  *   Mupen64plus - demo.c                                                  *
- *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
+ *   Mupen64Plus homepage: https://mupen64plus.org/                        *
  *   Copyright (C) 2008 Marshallh                                          *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *

--- a/mupen64plus/fifo.c
+++ b/mupen64plus/fifo.c
@@ -1,6 +1,6 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  *   Mupen64plus - fifo.c                                                  *
- *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
+ *   Mupen64Plus homepage: https://mupen64plus.org/                        *
  *   Copyright (C) 2008 Marshallh                                          *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *

--- a/mupen64plus/gfxlib.c
+++ b/mupen64plus/gfxlib.c
@@ -1,6 +1,6 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  *   Mupen64plus - hardware.h                                              *
- *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
+ *   Mupen64Plus homepage: https://mupen64plus.org/                        *
  *   Copyright (C) 2008 Marshallh                                          *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *

--- a/mupen64plus/graphics.h
+++ b/mupen64plus/graphics.h
@@ -1,6 +1,6 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  *   Mupen64plus - graphics.h                                              *
- *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
+ *   Mupen64Plus homepage: https://mupen64plus.org/                        *
  *   Copyright (C) 2008 Marshallh                                          *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *

--- a/mupen64plus/hardware.h
+++ b/mupen64plus/hardware.h
@@ -1,6 +1,6 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  *   Mupen64plus - hardware.h                                              *
- *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
+ *   Mupen64Plus homepage: https://mupen64plus.org/                        *
  *   Copyright (C) 2008 Marshallh                                          *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *

--- a/mupen64plus/include/config.h
+++ b/mupen64plus/include/config.h
@@ -1,6 +1,6 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  *   Mupen64plus - config.h                                                *
- *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
+ *   Mupen64Plus homepage: https://mupen64plus.org/                        *
  *   Copyright (C) 2008 Marshallh                                          *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *

--- a/mupen64plus/include/helpfunc.h
+++ b/mupen64plus/include/helpfunc.h
@@ -1,6 +1,6 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  *   Mupen64plus - helpfunc.h                                              *
- *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
+ *   Mupen64Plus homepage: https://mupen64plus.org/                        *
  *   Copyright (C) 2008 Marshallh                                          *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *

--- a/mupen64plus/include/types.h
+++ b/mupen64plus/include/types.h
@@ -1,6 +1,6 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  *   Mupen64plus - types.h                                                 *
- *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
+ *   Mupen64Plus homepage: https://mupen64plus.org/                        *
  *   Copyright (C) 2008 Marshallh                                          *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *

--- a/mupen64plus/make
+++ b/mupen64plus/make
@@ -1,6 +1,6 @@
 #/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 # *   Mupen64plus - make                                                    *
-# *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
+# *   Mupen64Plus homepage: https://mupen64plus.org/                        *
 # *   Copyright (C) 2008 Marshallh                                          *
 # *                                                                         *
 # *   This program is free software; you can redistribute it and/or modify  *

--- a/mupen64plus/sprite.h
+++ b/mupen64plus/sprite.h
@@ -1,6 +1,6 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  *   Mupen64plus - sprite.h                                                *
- *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
+ *   Mupen64Plus homepage: https://mupen64plus.org/                        *
  *   Copyright (C) 2008 Marshallh                                          *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *

--- a/mupen64plus/sprites/fade.h
+++ b/mupen64plus/sprites/fade.h
@@ -1,6 +1,6 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  *   Mupen64plus - fade.h                                                  *
- *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
+ *   Mupen64Plus homepage: https://mupen64plus.org/                        *
  *   Copyright (C) 2008 Marshallh                                          *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *

--- a/mupen64plus/stack.c
+++ b/mupen64plus/stack.c
@@ -1,6 +1,6 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  *   Mupen64plus - stack.c                                                 *
- *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
+ *   Mupen64Plus homepage: https://mupen64plus.org/                        *
  *   Copyright (C) 2008 Marshallh                                          *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *

--- a/mupen64plus/zbuf.c
+++ b/mupen64plus/zbuf.c
@@ -1,6 +1,6 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  *   Mupen64plus - zbuf.c                                                  *
- *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
+ *   Mupen64Plus homepage: https://mupen64plus.org/                        *
  *   Copyright (C) 2008 Marshallh                                          *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *


### PR DESCRIPTION
Linking to the Google Code page isn’t much use anymore.

Across all repos, I changed issue tracker links to the Github tracker, wiki links to the mupen64plus.org wiki, and homepage links to mupen64plus.org.

For the most part I didn’t link to individual repos, for maintenance reasons (if we ever move away from Github, or if we copy files across repos, or…).